### PR TITLE
Support for Redis connection without SSL certificate verification

### DIFF
--- a/lib/pubsubstub.rb
+++ b/lib/pubsubstub.rb
@@ -43,7 +43,7 @@ module Pubsubstub
     end
 
     def new_redis
-      Redis.new(url: redis_url)
+      Redis.new(url: redis_url, ssl_params: redis_ssl_params)
     end
 
     def subscriber
@@ -64,6 +64,16 @@ module Pubsubstub
     rescue => error
       handle_error(error)
       raise
+    end
+
+    def redis_ssl_params
+      if(ENV['REDIS_SSL_VERIFY'] == 'false')
+        {
+          verify_mode: OpenSSL::SSL::VERIFY_NONE
+        }
+      else
+        {}
+      end
     end
   end
 


### PR DESCRIPTION
Context: on Heroku Key-Value addon (Valkey fork of Redis), they use TLS but with a self-signed certificate, as described here:
* https://devcenter.heroku.com/articles/connecting-heroku-redis#external-connections
* https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance

This PR adds `REDIS_SSL_VERIFY` environment variable to make it work without patching Pubsubstub's class in-application.

A similar PR is coming to shipit-engine. EDIT: https://github.com/Shopify/shipit-engine/pull/1397

No test coverage because no existing spec covers Redis connection, should I add some?